### PR TITLE
Remove nullable ErrorCode

### DIFF
--- a/SecurionPay/Response/Error.cs
+++ b/SecurionPay/Response/Error.cs
@@ -19,7 +19,7 @@ namespace SecurionPay.Response
 
         [JsonProperty("code")]
         [JsonConverter(typeof(SafeEnumConverter))]
-        public ErrorCode? Code { get; set; }
+        public ErrorCode Code { get; set; }
 
         [JsonProperty("chargeId")]
         public String ChargeId { get; set; }


### PR DESCRIPTION
If the property ErrorCode is nullable must change the code in "SecurionPay.Converters.SafeEnumConverter" that with reflection don't find the enum value. This generate an error response when one card have some problem (like insufficient_funds).
.